### PR TITLE
Update gisfileinput.adoc

### DIFF
--- a/docs/usage/gisfileinput.adoc
+++ b/docs/usage/gisfileinput.adoc
@@ -52,6 +52,8 @@ Read GIS files from different formats.
 |===
 |Parameter | Required | Value
 |Force to multi geometries | ✓ | Yes / **No**
+3+|**Notes**
+3+|Formats such as GeoJSON allow objects to contain different fields ('schemaless'). However, Hop requires a schema definition (i.e. field descriptions) that is consistent across all objects in an input stream. Therefore, the GIS File Input must extract the schema definition from the data. This is done using the properties of the first GeoJSON object.
 |===
 
 ## `GeoPackage` : Other parameters


### PR DESCRIPTION
Added a note informing the user that GIS File Input of a GeoJSON file uses the properties of the first GeoJSON object in order to extract the schema definition.